### PR TITLE
Search filter join support

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -16,6 +16,7 @@ this.Searcher = (function() {
     this.SEARCH_FILTER_OPERATOR_KEY = 'operator';
     this.SEARCH_FILTER_VALUE_KEY    = 'value';
     this.SEARCH_FILTER_FORMULA_KEY  = 'formula';
+    this.SEARCH_FILTER_JOIN_KEY     = 'join';    
 
     this.SEARCH_COLUMN_NAME_KEY = 'name';
     this.SEARCH_COLUMN_JOIN_KEY = 'join';
@@ -140,6 +141,7 @@ this.Searcher = (function() {
     searchFilterData[this.SEARCH_FILTER_NAME_KEY]     = 'internalidnumber';
     searchFilterData[this.SEARCH_FILTER_OPERATOR_KEY] = 'greaterthan';
     searchFilterData[this.SEARCH_FILTER_VALUE_KEY]    = this.lowerBound;
+    searchFilterData[this.SEARCH_FILTER_JOIN_KEY]     = null;
 
     lowerBoundFilterObject = this.getSearchFilterObject(searchFilterData)
     this.searchFilters[this.lowerBoundFilterIndex] = lowerBoundFilterObject;
@@ -157,7 +159,8 @@ this.Searcher = (function() {
     name     = searchFilterData[this.SEARCH_FILTER_NAME_KEY];
     operator = searchFilterData[this.SEARCH_FILTER_OPERATOR_KEY];
     value    = searchFilterData[this.SEARCH_FILTER_VALUE_KEY];
-    filter = NetsuiteToolkit.searchFilter(name, null, operator, value);
+    join	 = searchFilterData[this.SEARCH_FILTER_JOIN_KEY];
+    filter = NetsuiteToolkit.searchFilter(name, join, operator, value);
     return filter;
   }
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -141,7 +141,6 @@ this.Searcher = (function() {
     searchFilterData[this.SEARCH_FILTER_NAME_KEY]     = 'internalidnumber';
     searchFilterData[this.SEARCH_FILTER_OPERATOR_KEY] = 'greaterthan';
     searchFilterData[this.SEARCH_FILTER_VALUE_KEY]    = this.lowerBound;
-    searchFilterData[this.SEARCH_FILTER_JOIN_KEY]     = null;
 
     lowerBoundFilterObject = this.getSearchFilterObject(searchFilterData)
     this.searchFilters[this.lowerBoundFilterIndex] = lowerBoundFilterObject;
@@ -160,6 +159,8 @@ this.Searcher = (function() {
     operator = searchFilterData[this.SEARCH_FILTER_OPERATOR_KEY];
     value    = searchFilterData[this.SEARCH_FILTER_VALUE_KEY];
     join	 = searchFilterData[this.SEARCH_FILTER_JOIN_KEY];
+    if (typeof join == 'undefined')join = null;
+    
     filter = NetsuiteToolkit.searchFilter(name, join, operator, value);
     return filter;
   }


### PR DESCRIPTION
Currently there appears no way to specify criteria fields from join - ed tables, though the feature exists in the NS API. (maybe the formula field is for this but im not sure either)

This patch simply exposes the setting as an extra optional parameter 'join' to the Search request parameter 'search_filters', rather than it just always being set to null.