### PR TITLE
Search sorting by custom column

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -36,6 +36,7 @@ this.Searcher = (function() {
     this.searchFilters         = [];
     this.searchColumns         = [];
     this.results               = [];
+    this.sortSet               = false;
 
     intBatchSize = parseInt(this.originalBatchSize);
     if((intBatchSize % 1000) != 0) {
@@ -46,7 +47,7 @@ this.Searcher = (function() {
     this.createSearchFilters();
     this.generateLowerBoundFilter();
     this.createSearchColumns();
-    this.generateSortColumn();
+    if(!this.sortSet)this.generateSortColumn();
   }
 
   /**
@@ -202,7 +203,12 @@ this.Searcher = (function() {
   Searcher.prototype.getSearchColumnObject = function(searchColumnData) {
     name = searchColumnData[this.SEARCH_COLUMN_NAME_KEY];
     join = searchColumnData[this.SEARCH_COLUMN_JOIN_KEY];
+    sort = searchColumnData[this.SEARCH_COLUMN_SORT_KEY];
     column = NetsuiteToolkit.searchColumn(name, join);
+    if (typeof sort != 'undefined'){
+      	column.setSort((sort == 'true'));
+      	this.sortSet = true;
+    }
     return column;
   }
 


### PR DESCRIPTION
The sort boolean option for a search column appears to have never been created. It only ever sorts ASC by internalid regardless,This fixes that.
Column can also be set ASC or DESC
Descending: 'sort' = 'true'
Ascending: 'sort' = 'false'
Was not sure if to use string or bool , so went with string to fit in with the rest of the options. so 'true' works but true does not, this could be changed.
If a column is set to sort, then the default internalid sort column is not added.
With this patch multiple columns can be set to sort, though i have no idea if this works or not, compared with the readme stated action (which does not exist) to only sort by last column set to sort.