### PR TITLE
Search column join groups and labels

### DIFF
--- a/lib/saved_search.js
+++ b/lib/saved_search.js
@@ -158,7 +158,32 @@ this.SavedSearch = (function() {
    * @return {null}
    */
   SavedSearch.prototype.appendResults = function(resultsBlock) {
-    this.results = this.results.concat(resultsBlock);
+    var newResultsBlock = [];
+    for ( var i = 0; resultsBlock != null && i < resultsBlock.length; i++ )
+    {
+      	var newResult = {"id":resultsBlock[i].getId(), "recordtype":resultsBlock[i].getRecordType(), "columns":{}};
+      	var result = resultsBlock[i];
+      	var columns = result.getAllColumns();
+      	var columnLen = columns.length;
+
+      	for (x = 0; x < columnLen; x++)
+         {
+           var column = columns[x];
+           var name = column.getName();
+           var label = column.getLabel();
+           var join = column.getJoin();
+           var value = result.getValue(column);
+           var nameOrLabel = (label ? label : name);
+           if(join && !label){
+             	join += 'Join';
+             	if(!(join in newResult.columns))newResult.columns[join] = {};
+				      newResult.columns[join][nameOrLabel] = value;
+           }
+           else newResult.columns[nameOrLabel] = value;
+         }
+     	    newResultsBlock.push(newResult);
+    }
+    this.results = this.results.concat(newResultsBlock);
   }
 
   /**

--- a/lib/saved_search.js
+++ b/lib/saved_search.js
@@ -173,15 +173,18 @@ this.SavedSearch = (function() {
            var label = column.getLabel();
            var join = column.getJoin();
            var value = result.getValue(column);
-           var nameOrLabel = (label ? label : name);
+           var text = result.getText(column);
+           var joinTitle = join + 'Join';
+           var columnTitle = (label ? label : name);
+           if(text && (text !== value))var columnData = {'name':text, 'internalId':value};
+           else columnData = value;           
            if(join && !label){
-             	join += 'Join';
-             	if(!(join in newResult.columns))newResult.columns[join] = {};
-				      newResult.columns[join][nameOrLabel] = value;
+             	if(!(joinTitle in newResult.columns))newResult.columns[joinTitle] = {};
+				newResult.columns[joinTitle][columnTitle] = columnData;
            }
-           else newResult.columns[nameOrLabel] = value;
+           else newResult.columns[columnTitle] = columnData;
          }
-     	    newResultsBlock.push(newResult);
+     	 newResultsBlock.push(newResult);
     }
     this.results = this.results.concat(newResultsBlock);
   }

--- a/lib/search.js
+++ b/lib/search.js
@@ -340,15 +340,18 @@ this.Searcher = (function() {
            var label = column.getLabel();
            var join = column.getJoin();
            var value = result.getValue(column);
-           var nameOrLabel = (label ? label : name);
+           var text = result.getText(column);
+           var joinTitle = join + 'Join';
+           var columnTitle = (label ? label : name);
+           if(text && (text !== value))var columnData = {'name':text, 'internalid':value};
+           else columnData = value;           
            if(join && !label){
-             	join += 'Join';
-             	if(!(join in newResult.columns))newResult.columns[join] = {};
-				      newResult.columns[join][nameOrLabel] = value;
+             	if(!(joinTitle in newResult.columns))newResult.columns[joinTitle] = {};
+				newResult.columns[joinTitle][columnTitle] = columnData;
            }
-           else newResult.columns[nameOrLabel] = value;
+           else newResult.columns[columnTitle] = columnData;
          }
-     	   newResultsBlock.push(newResult);
+     	 newResultsBlock.push(newResult);
     }
     this.results = this.results.concat(newResultsBlock);
   }

--- a/lib/search.js
+++ b/lib/search.js
@@ -325,7 +325,32 @@ this.Searcher = (function() {
    * @return {null}
    */
   Searcher.prototype.appendResults = function(resultsBlock) {
-    this.results = this.results.concat(resultsBlock);
+    var newResultsBlock = [];
+    for ( var i = 0; resultsBlock != null && i < resultsBlock.length; i++ )
+    {
+      	var newResult = {"id":resultsBlock[i].getId(), "recordtype":resultsBlock[i].getRecordType(), "columns":{}};
+      	var result = resultsBlock[i];
+      	var columns = result.getAllColumns();
+      	var columnLen = columns.length;
+
+      	for (x = 0; x < columnLen; x++)
+         {
+           var column = columns[x];
+           var name = column.getName();
+           var label = column.getLabel();
+           var join = column.getJoin();
+           var value = result.getValue(column);
+           var nameOrLabel = (label ? label : name);
+           if(join && !label){
+             	join += 'Join';
+             	if(!(join in newResult.columns))newResult.columns[join] = {};
+				      newResult.columns[join][nameOrLabel] = value;
+           }
+           else newResult.columns[nameOrLabel] = value;
+         }
+     	   newResultsBlock.push(newResult);
+    }
+    this.results = this.results.concat(newResultsBlock);
   }
 
   /**

--- a/lib/search.js
+++ b/lib/search.js
@@ -343,7 +343,7 @@ this.Searcher = (function() {
            var text = result.getText(column);
            var joinTitle = join + 'Join';
            var columnTitle = (label ? label : name);
-           if(text && (text !== value))var columnData = {'name':text, 'internalid':value};
+           if(text && (text !== value))var columnData = {'name':text, 'internalId':value};
            else columnData = value;           
            if(join && !label){
              	if(!(joinTitle in newResult.columns))newResult.columns[joinTitle] = {};


### PR DESCRIPTION
Now joined columns go in their respective join titled array, to get around columns with same names from different joins clashing.

Also (more for saved searches), a column assigned a label will override its default name, useful for preserving multiple same type formula columns.