### PR TITLE
Upsert bug fixes

### DIFF
--- a/lib/netsuite_toolkit.js
+++ b/lib/netsuite_toolkit.js
@@ -305,6 +305,7 @@ NetsuiteToolkit.SublistProcessor = (function() {
     this.create_list  = sublist_data['create'] || [];
     this.update_list  = sublist_data['update'] || [];
     this.excise_list  = sublist_data['excise'] || [];
+    this.bySelect     = sublist_data['bySelect'] || false;
   }
 
   /**
@@ -371,12 +372,17 @@ NetsuiteToolkit.SublistProcessor = (function() {
   SublistProcessor.prototype.createLineItem = function(creation_request) {
     index = creation_request['index'];
     data  = creation_request['data'];
-
-    if(!index) {
-      index = NetsuiteToolkit.getLineItemCount(this.record, this.sublist_name);
+	  if(!this.bySelect){
+      if(!index) {
+        index = NetsuiteToolkit.getLineItemCount(this.record, this.sublist_name);
+      }
+      NetsuiteToolkit.insertLineItem(this.record, this.sublist_name, index);
+      this.updateLineItemFields(index, data);
+    }else{
+      this.record.selectNewLineItem(this.sublist_name)
+      this.updateLineItemFields(index, data);
+      this.record.commitLineItem(this.sublist_name)
     }
-    NetsuiteToolkit.insertLineItem(this.record, this.sublist_name, index);
-    this.updateLineItemFields(index, data);
   }
 
   /**
@@ -435,7 +441,8 @@ NetsuiteToolkit.SublistProcessor = (function() {
   SublistProcessor.prototype.updateLineItemFields = function(index, line_item_data) {
     for(field in line_item_data) {
       value = line_item_data[field];
-      NetsuiteToolkit.setLineItemValue(this.record, this.sublist_name, field, index, value);
+      if(!this.bySelect)NetsuiteToolkit.setLineItemValue(this.record, this.sublist_name, field, index, value);
+      else this.record.setCurrentLineItemValue(this.sublist_name, field, value);
     }
   }
 

--- a/lib/upsert.js
+++ b/lib/upsert.js
@@ -61,7 +61,7 @@ this.Upserter = (function() {
    * @return {object} The object containing a formatted summary of the results of the request
    */
   Upserter.prototype.generateReply = function() {
-    return NetsuiteToolkit.formatReply(this.params, this.replyList);
+    return NetsuiteToolkit.formatReply(this.params, this.reply_list);
   }
 
   return Upserter;
@@ -95,7 +95,7 @@ this.UpsertRequest = (function() {
    * @return {null}
    */
   UpsertRequest.prototype.execute = function() {
-    this.record = this.loadOrInitializeRecord();
+    this.loadOrInitializeRecord();
     NetsuiteToolkit.RecordProcessor.updateLiterals(this.record, this.literal_field_data);
     this.processSublists();
     this.written_id = NetsuiteToolkit.submitRecord(this.record);


### PR DESCRIPTION
wildkatana's fixes plus:

trying to add an item sublist row to for example a sales order can return a SSS_INVALID_SUBLIST_OPERATION error, this is due to dynamic mode. way around it is to use setCurrentLineItemValue etc instead. this patch just checks for param bySelect in the sublist and uses this method instead, there may be other sublist types that need this, and a more comprehensive integration of these methods, but it works for me for now and thats enough for now...

